### PR TITLE
chore: remove redundant filling of delta empty delta columns, already…

### DIFF
--- a/peptide_forest/training.py
+++ b/peptide_forest/training.py
@@ -214,12 +214,6 @@ def fit_cv(df, score_col, cv_split_data, sensitivity, q_cut):
         train = df.loc[train_inds.tolist(), :].copy(deep=True)
         test = df.loc[test_inds.tolist(), :].copy(deep=True)
 
-        # Fill missing data
-        delta_cols = [c for c in train.columns if "delta_score" in c]
-        min_per_delta_col = train[delta_cols].min()
-        train.loc[:, delta_cols].fillna(min_per_delta_col, inplace=True)
-        test.loc[:, delta_cols].fillna(min_per_delta_col, inplace=True)
-
         # Use only top target and top decoy per spectrum
         train_data = (
             train.sort_values(score_col, ascending=False)


### PR DESCRIPTION
Missing values in Delta Cols were filled during training, which is redundant as this step is already performed on the whole data frame.

Note: If the min value should be set again on the min value for only the subset of data used in this training iteration (the train df) this PR can be rejected (in this case a logical error persists in setting the min value of the train df AND the test df to the min value obtained from the train df).